### PR TITLE
Fixing Falky Test ordering issue in StateTtlHintTest.java

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -96,6 +96,7 @@ import java.time.Duration
 import java.util.Collections
 
 import scala.collection.JavaConverters._
+import scala.util.matching.Regex
 
 /** Test base for testing Table API / SQL plans. */
 abstract class TableTestBase {
@@ -1171,19 +1172,44 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
 
   def assertEqualsOrExpand(tag: String, actual: String, expand: Boolean = true): Unit = {
     val expected = s"$${$tag}"
+    val normalizedActual = normalizeStateTtlOptions(actual)
+    val normalizedExpected = normalizeStateTtlOptions(expected)
     if (!expand) {
-      diffRepository.assertEquals(test.methodName, tag, expected, actual)
+      diffRepository.assertEquals(test.methodName, tag, normalizedExpected, normalizedActual)
       return
     }
     val expanded = diffRepository.expand(test.methodName, tag, expected)
     if (expanded != null && !expanded.equals(expected)) {
       // expected does exist, check result
-      diffRepository.assertEquals(test.methodName, tag, expected, actual)
+      diffRepository.assertEquals(test.methodName, tag, normalizedExpected, normalizedActual)
     } else {
       // expected does not exist, update
       diffRepository.expand(test.methodName, tag, actual)
     }
   }
+
+  def normalizeStateTtlOptions(plan: String): String = {
+    val stateTtlOptionsPattern: Regex = """(STATE_TTL[^\{]*\{)([^\}]*)(\})""".r
+
+    def normalizeOptions(options: String): String = {
+      options
+        .split(", ")
+        .map(_.trim)
+        .sortBy(_.split("=")(0))
+        .mkString(", ")
+    }
+
+    def normalizeStateTtlOptionsMatch(m: Regex.Match): String = {
+      val prefix = m.group(1)
+      val options = m.group(2)
+      val suffix = m.group(3)
+      val normalizedOptions = normalizeOptions(options)
+      s"$prefix$normalizedOptions$suffix"
+    }
+
+    stateTtlOptionsPattern.replaceAllIn(plan, normalizeStateTtlOptionsMatch _)
+  }
+
 }
 
 abstract class TableTestUtil(


### PR DESCRIPTION
## What is the purpose of the change

Fixing flaky test in org.apache.flink.table.planner.plan.hints.stream.StateTtlHintTest#testStateTtlHintWithJoinHint. This flaky test sometimes fails due to the indeterministic ordering of the ‘options’ in the optimized query plan that is produced while the verify() function within the testStateTtlHintWithJoinHint() test case is invoked in the StateTtlHintTest.java file.

## Brief change log

- The test case testStateTtlHintWithJoinHint() passes the sql query to a verify() function in oder to test for the optimized query plan
- The verify() function in turn calls a doVerifyPlan() function which is defined within the TableTestBase.scala file. 
- The doVerifyPlan() in turn invokes assertPlanEquals() function which in turn invokes assertEqualsOrExpand() function
- Since the optimized query plan is being produced and tested finally within this assertEqualsOrExpand() function, all my changes have being implemented within this function only. 
- I have normalized the actual and expected values so that the ‘options’ are always sorted through regex before the final  assertion takes place

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage. 

This change can be tested using this command: mvn -pl flink-table/flink-table-planner     edu.illinois:nondex-maven-plugin:2.1.7:nondex     -Dtest=org.apache.flink.table.planner.plan.hints.stream.StateTtlHintTest#testStateTtlHintWithJoinHint -DnondexRuns=10. This confirms that the test passes for all the 10 nondex iterations. 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? No